### PR TITLE
Pointing to latest rumprun (including fix for /tmpfs and /dev)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ before_install:
 
 script:
   - git submodule update --init --recursive
-  - make -j2 world > /dev/null
+  - bash travis_wait.sh 60 make -j2 --quiet world
   - make integration

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -35,9 +35,14 @@ submodule_warning:
 
 endif
 
+libsolo5 = $(TOP)/rumprun/rumprun-solo5/rumprun-x86_64/lib/rumprun-solo5/libsolo5_seccomp.a
+
 .PHONY: rumprun
-rumprun: FORCE submodule_warning
+rumprun: FORCE submodule_warning $(libsolo5)
 	make -C $(TOP)/rumprun build
+
+$(libsolo5): FORCE solo5
+	install -m 664 -D $(TOP)/solo5/kernel/ukvm/solo5.o $@
 
 rumprun-clean:
 	make -C $(TOP)/rumprun clean

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -49,7 +49,7 @@ rumprun-clean:
 
 .PHONY: solo5
 solo5: FORCE submodule_warning
-	make -C $(TOP)/solo5 ukvm
+	make -C $(TOP)/solo5
 
 solo5-clean:
 	make -C $(TOP)/solo5 clean

--- a/node-base/Dockerfile
+++ b/node-base/Dockerfile
@@ -1,10 +1,5 @@
 FROM scratch
 
-# XXX: This is a temporary horrible hack which should disappear as soon as we
-# fix a rumprun issue we introduced by trying to mount the root which is over
-# writing rumprun's /dev devices (like random).
-COPY dev /dev
-
 COPY node.nabla /node.nabla
 
 ENTRYPOINT ["/node.nabla"]

--- a/node-base/Makefile
+++ b/node-base/Makefile
@@ -34,19 +34,11 @@ rumprun-packages-nodejs: rumprun solo5 FORCE
 rumprun-packages-nodejs-clean:
 	make -C $(RUMPPKGS)/nodejs clean
 
-# XXX: This is a temporary horrible hack which should disappear as soon as we
-# fix a rumprun issue we introduced by trying to mount the root which is over
-# writing rumprun's /dev devices (like random).
-dev:
-	mkdir -p dev
-	dd if=/dev/urandom of=dev/urandom count=1024 bs=1024
-	dd if=/dev/urandom of=dev/random count=1024 bs=1024
-
-build_docker: submodule_warning $(FILES) dev rumprun-packages-nodejs
+build_docker: submodule_warning $(FILES) rumprun-packages-nodejs
 	sudo docker build -f Dockerfile -t nabla-node-base .
 	sudo docker tag nabla-node-base nablact/nabla-node-base
 
 clean:
-	rm -rf dev node.nabla
+	rm -rf node.nabla
 
 distclean: clean rumprun-packages-nodejs-clean solo5-clean rumprun-clean

--- a/python3-base/Dockerfile
+++ b/python3-base/Dockerfile
@@ -1,16 +1,10 @@
 FROM python:3.5.2-alpine
-RUN apk update && apk add iproute2 git
 
 # The first stage is just for the second one to get /usr/local/lib/python in it,
 # which is needed by python.
 
 FROM scratch
 COPY python3.nabla /python3.nabla
-
-# XXX: This is a temporary horrible hack which should disappear as soon as we
-# fix a rumprun issue we introduced by trying to mount the root which is over
-# writing rumprun's /dev devices (like random).
-COPY dev /dev
 
 COPY rootfs /
 COPY --from=0 /usr/local/lib /usr/local/lib

--- a/python3-base/Makefile
+++ b/python3-base/Makefile
@@ -43,19 +43,11 @@ rumprun-packages-python3: rumprun solo5 FORCE
 rumprun-packages-python3-clean:
 	make -C $(RUMPPKGS)/python3 clean
 
-# XXX: This is a temporary horrible hack which should disappear as soon as we
-# fix a rumprun issue we introduced by trying to mount the root which is over
-# writing rumprun's /dev devices (like random).
-dev:
-	mkdir -p dev
-	dd if=/dev/urandom of=dev/urandom count=1024 bs=1024
-	dd if=/dev/urandom of=dev/random count=1024 bs=1024
-
-build_docker: submodule_warning $(FILES) dev rumprun-packages-python3
+build_docker: submodule_warning $(FILES) rumprun-packages-python3
 	sudo docker build -f Dockerfile -t nabla-python3-base .
 	sudo docker tag nabla-python3-base nablact/nabla-python3-base
 
 clean:
-	rm -rf dev python3.nabla
+	rm -rf python3.nabla
 
 distclean: clean rumprun-packages-python3-clean solo5-clean rumprun-clean

--- a/travis_wait.sh
+++ b/travis_wait.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright (c) 2016 Travis CI GmbH <contact@travis-ci.org>
+#
+# SPDX-License-Identifier: MIT
+#
+# Based on the travis-ci/travis-build
+
+travis_jigger() {
+  # helper method for travis_wait()
+  local cmd_pid=$1
+  shift
+  local timeout=$1 # in minutes
+  shift
+  local count=0
+
+  # clear the line
+  echo -e "\n"
+
+  while [ $count -lt $timeout ]; do
+    count=$(($count + 1))
+    echo -ne "Still running ($count of $timeout): $@\r"
+    sleep 60
+  done
+
+  echo -e "\n${ANSI_RED}Timeout (${timeout} minutes) reached. Terminating \"$@\"${ANSI_RESET}\n"
+  kill -9 $cmd_pid
+}
+
+travis_wait() {
+  local timeout=$1
+
+  if [[ $timeout =~ ^[0-9]+$ ]]; then
+    # looks like an integer, so we assume it's a timeout
+    shift
+  else
+    # default value
+    timeout=20
+  fi
+
+  local cmd="$@"
+  local log_file=travis_wait_$$.log
+
+  $cmd &>$log_file &
+  local cmd_pid=$!
+
+  travis_jigger $! $timeout $cmd &
+  local jigger_pid=$!
+  local result
+
+  {
+    wait $cmd_pid 2>/dev/null
+    result=$?
+    ps -p$jigger_pid &>/dev/null && kill $jigger_pid
+  } || return 1
+
+  if [ $result -eq 0 ]; then
+    echo -e "\n${ANSI_GREEN}The command \"$TRAVIS_CMD\" exited with $result.${ANSI_RESET}"
+  else
+    echo -e "\n${ANSI_RED}The command \"$TRAVIS_CMD\" exited with $result.${ANSI_RESET}"
+  fi
+
+  echo -e "\n${ANSI_GREEN}Log:${ANSI_RESET}\n"
+  tail -n 200 $log_file
+
+  return $result
+}
+
+travis_wait $@


### PR DESCRIPTION
This points to the latest rumprun, which has some cleanup: a bunch of useless files are deleted, test_blk is fixed, and most importantly, the fix for having /dev/ and a writable tmpfs is ready.

Signed-off-by: Ricardo Koller <kollerr@us.ibm.com>