### PR TITLE
postmark base

### DIFF
--- a/postmark-base/.gitignore
+++ b/postmark-base/.gitignore
@@ -1,0 +1,2 @@
+data.lfs
+postmark.nabla

--- a/postmark-base/Dockerfile
+++ b/postmark-base/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+
+COPY postmark.nabla /postmark.nabla
+COPY benchmark.pmrc /benchmark.pmrc
+
+ENTRYPOINT ["/postmark.nabla"]

--- a/postmark-base/Makefile
+++ b/postmark-base/Makefile
@@ -1,0 +1,45 @@
+# Copyright (c) 2018 Contributors as noted in the AUTHORS file
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+# OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+export TOP=$(abspath ..)
+all: build_docker
+
+RUMPPKGS=$(TOP)/rumprun-packages
+RUMPRUN=$(TOP)/rumprun
+include ../Makefile.inc
+
+FILES=\
+benchmark.pmrc \
+Dockerfile \
+Makefile \
+
+.PHONY: rumprun-packages-postmark
+rumprun-packages-postmark: rumprun solo5 FORCE
+	install -m 664 -D $(RUMPPKGS)/config.mk.dist $(RUMPPKGS)/config.mk
+	source $(RUMPRUN)/obj/config-PATH.sh && make -C $(RUMPPKGS)/postmark all bin/postmark.seccomp
+	install -m 775 -D $(RUMPPKGS)/postmark/bin/postmark.seccomp postmark.nabla
+
+rumprun-packages-postmark-clean:
+	make -C $(RUMPPKGS)/postmark clean
+
+build_docker: submodule_warning $(FILES) rumprun-packages-postmark
+	sudo docker build -f Dockerfile -t nabla-postmark-base .
+	sudo docker tag nabla-postmark-base nablact/nabla-postmark-base
+
+clean:
+	rm -rf postmark.nabla
+
+distclean: clean rumprun-packages-postmark-clean solo5-clean rumprun-clean

--- a/postmark-base/benchmark.pmrc
+++ b/postmark-base/benchmark.pmrc
@@ -1,0 +1,5 @@
+set transactions 2500
+set size 5120 524288
+set number 500
+run
+quit

--- a/postmark-base/postmark_nabla_test.bash
+++ b/postmark-base/postmark_nabla_test.bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# runnc can't run programs that write to the disk yet because it
+# places files in a temporary filesystem.  As a result, postmark (this
+# fs benchmark) will not work using runnc.  This script is a
+# workaround to directly run the process (not as a Docker container).
+
+# Usage: bash ./postmark_nabla_test.bash ./benchmark.pmrc
+PMRC=$1
+
+### If you don't have tap100, do this:
+# sudo ip tuntap add tap100 mode tap
+# sudo ip addr add 10.0.0.1/24 dev tap100
+# sudo ip link set dev tap100 up
+
+mkdir /tmp/data
+cp $PMRC /tmp/data/benchmark.pmrc
+
+### If you don't have genlfs, get it from https://github.com/ricarkol/genlfs
+genlfs /tmp/data/ data.lfs
+
+### If you don't have nabla-run, get it from https://github.com/nabla-containers/runnc
+nabla-run --disk=data.lfs --net=tap100 postmark.nabla '{"cmdline":"bin/postmark.nabla /data/benchmark.pmrc","net":{"if":"ukvmif0","cloner":"True","type":"inet","method":"static","addr":"10.0.0.2","mask":"16"},"blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/data"}}'


### PR DESCRIPTION
This is a nabla-base-build for the postmark fs benchmark.  It goes along with a https://github.com/nabla-containers/rumprun-packages/pull/5 which is a new rumprun-packages entity to build postmark on rumprun.  

There is a major blocker to this working like the others, which is the fact that the benchmark requires a writeable filesystem, which runnc does not support (runnc only creates and exposes guest filesystems as read-only isos).  To get around this, I have supplied a script to run the `postmark.nabla` directly with `nabla-run`, using an lfs image.

I'd like to merge this anyway, since I think it would be useful both as an example of how to create new (simple) rumprun-packages for nabla, as well as experiments to evaluate new filesystems that are candidates to expose through runnc.

Before this gets merged, the other PR https://github.com/nabla-containers/rumprun-packages/pull/5 should be merged and the submodule pointer should be updated.